### PR TITLE
Allow stable to build with 13.2, too

### DIFF
--- a/rpm/kernel-docs.spec.in
+++ b/rpm/kernel-docs.spec.in
@@ -23,7 +23,7 @@
 
 %define use_fop	1
 
-%if %{?is_opensuse}
+%if 0%{?is_opensuse} || 0%{?suse_version} == 1320
 %define use_sphinx 1
 %else
 %define use_sphinx 0


### PR DESCRIPTION
The macro is_opensuse is defined in most recent distros only, resulting in a failed build otherwise.
