### PR TITLE
rpm: group-source-files.pl: Add arch/*/tools/* files to the devel package

### DIFF
--- a/rpm/group-source-files.pl
+++ b/rpm/group-source-files.pl
@@ -40,6 +40,7 @@ sub scan
 			m{^\Q$loc\E/arch/arm/[^/]+/include/mach\b} ||
 			m{^\Q$loc\E/arch/arm/[^/]+/include/plat\b} ||
 			m{^\Q$loc\E/arch/[^/]+/scripts\b} ||
+			m{^\Q$loc\E/arch/[^/]+/tools\b} ||
 			m{^\Q$loc\E/include/[^/]+\b} ||
 			m{^\Q$loc\E/scripts\b};
 		if (substr($_, 0, 1) ne "/") {


### PR DESCRIPTION
Commit b71c9ffb1405 ("powerpc: Add arch/powerpc/tools directory")
introduced in v4.12-rc1 release, moved the scripts into the tools
directory. However, this location is not considered for the kernel devel
package and the following error occurs when building a kmp for powerpc

make[2]: /usr/src/linux-4.12.9-1/arch/powerpc/tools/gcc-check-mprofile-kernel.sh: Command not found