### PR TITLE
ARM: 8904/1: skip nomap memblocks while finding the lowmem/highmem boundary (bsc#1122614).

### DIFF
--- a/patches.suse/0001-ARM-8904-1-skip-nomap-memblocks-while-finding-the-lo.patch
+++ b/patches.suse/0001-ARM-8904-1-skip-nomap-memblocks-while-finding-the-lo.patch
@@ -1,0 +1,36 @@
+From: Chester Lin <clin@suse.com>
+Date: Fri, 30 Aug 2019 14:30:07 +0100
+Subject: [PATCH] ARM: 8904/1: skip nomap memblocks while finding the
+ lowmem/highmem boundary
+
+Git-commit: 1d31999cf04c21709f72ceb17e65b54a401330da
+Patch-mainline: v5.4-rc1
+References: bsc#1122614
+
+adjust_lowmem_bounds() checks every memblocks in order to find the boundary
+between lowmem and highmem. However some memblocks could be marked as NOMAP
+so they are not used by kernel, which should be skipped while calculating
+the boundary.
+
+Signed-off-by: Chester Lin <clin@suse.com>
+Reviewed-by: Mike Rapoport <rppt@linux.ibm.com>
+Signed-off-by: Russell King <rmk+kernel@armlinux.org.uk>
+---
+ arch/arm/mm/mmu.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm/mm/mmu.c b/arch/arm/mm/mmu.c
+index d5e0b908f0ba..25da9b2d9610 100644
+--- a/arch/arm/mm/mmu.c
++++ b/arch/arm/mm/mmu.c
+@@ -1197,6 +1197,9 @@ void __init adjust_lowmem_bounds(void)
+ 		phys_addr_t block_start = reg->base;
+ 		phys_addr_t block_end = reg->base + reg->size;
+ 
++		if (memblock_is_nomap(reg))
++			continue;
++
+ 		if (reg->base < vmalloc_limit) {
+ 			if (block_end > lowmem_limit)
+ 				/*
+

--- a/series.conf
+++ b/series.conf
@@ -920,6 +920,7 @@
 	patches.suse/0001-clk-bcm2835-Introduce-SoC-specific-clock-registratio.patch
 	patches.suse/0001-clk-bcm2835-Add-BCM2711_CLOCK_EMMC2-support.patch
 	patches.suse/0001-clk-bcm2835-Mark-PLLD_PER-as-CRITICAL.patch
+	patches.suse/0001-ARM-8904-1-skip-nomap-memblocks-while-finding-the-lo.patch
 
 	patches.suse/V4-01-10-bluetooth-hci_bcm-Fix-RTS-handling-during-startup.patch
 	patches.suse/V4-02-10-ARM-dts-bcm283x-Remove-simple-bus-from-fixed-clocks.patch


### PR DESCRIPTION
A fix for bsc#1122614. This patch has been merged into Linus tree since v5.4-rc1. It must be with the patch 00d2ec1e6bd8 "ARM: 8903/1: ensure that usable memory in bank 0 starts from a PMD-aligned address" in order to solve the efistub issue on rpi-2.