### PR TITLE
Don't self obsolete older kernel variants

### DIFF
--- a/rpm/mkspec
+++ b/rpm/mkspec
@@ -481,7 +481,7 @@ sub provides_obsoletes {
 				$printed = 1;
 			}
 			$res .= "Provides:       $name = $version\n";
-			$res .= "Obsoletes:      $name <= $version\n";
+			$res .= "Obsoletes:      $name < $version\n";
 		}
 		$res .= "\%endif\n" if $printed;
 	}


### PR DESCRIPTION
Fixes [boo#1170232](https://bugzilla.opensuse.org/show_bug.cgi?id=1170232 "Kernel spec self obsoletes"), by no longer obsoleting itself