### PR TITLE
These patches avoid some build issues

### DIFF
--- a/patches.suse/0001-scripts-check-local-export-use-bin-bash-in.patch
+++ b/patches.suse/0001-scripts-check-local-export-use-bin-bash-in.patch
@@ -1,0 +1,24 @@
+From a1b1c316125e701e739c18e0bc9cb7b63d693267 Mon Sep 17 00:00:00 2001
+From: Hans-Peter Jansen <hp.jansen@suse.com>
+Date: Sat, 13 Aug 2022 12:25:49 +0200
+Patch-mainline: Never, carry this change until upstream provides better method
+References: none
+Subject: [PATCH] scripts/check-local-export: use /bin/bash in #!
+
+---
+ scripts/check-local-export | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/check-local-export b/scripts/check-local-export
+index 6ccc2f467416..3930a71c4ce3 100755
+--- a/scripts/check-local-export
++++ b/scripts/check-local-export
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env bash
++#!/bin/bash
+ # SPDX-License-Identifier: GPL-2.0-only
+ #
+ # Copyright (C) 2022 Masahiro Yamada <masahiroy@kernel.org>
+-- 
+2.37.1
+

--- a/rpm/kernel-binary.spec.in
+++ b/rpm/kernel-binary.spec.in
@@ -1391,7 +1391,7 @@ Requires(post): suse-module-tools >= 12.4
 %files -n @KMP_NAME@-%build_flavor -f @KMP_NAME@.files
 %defattr(-, root, root)
 # END KMP
-%endif # %CONFIG_SUSE_KERNEL_SUPPORTED
-%endif # %CONFIG_MODULES
+%endif
+%endif
 
 %changelog

--- a/series.conf
+++ b/series.conf
@@ -122,6 +122,7 @@
 	patches.suse/kernel-add-product-identifying-information-to-kernel-build.patch
 	patches.suse/kernel-add-release-status-to-kernel-build.patch
 	patches.suse/panic-do-not-print-uninitialized-taint_flags.patch
+	patches.suse/0001-scripts-check-local-export-use-bin-bash-in.patch
 
 	# build tweaks for external KMPs
 	patches.suse/s390-export-symbols-for-crash-kmp.patch


### PR DESCRIPTION
The first results in strange build issues of kmp packages with older user space:

```
[   84s]   printf '%s\n'   v4l2loopback.o | awk '!x[$0]++ { print("/home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default/"$0) }' > /home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default/v4l2loopback.mod
[   86s]   /usr/src/linux-5.19.1-lp152.9/scripts/check-local-export /home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default/v4l2loopback.o
[   86s] /bin/sh: /usr/src/linux-5.19.1-lp152.9/scripts/check-local-export: /usr/bin/bash: bad interpreter: No such file or directory
[   86s] make[1]: *** [/usr/src/linux-5.19.1-lp152.9/scripts/Makefile.build:250: /home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default/v4l2loopback.o] Error 126
[   86s] make[1]: *** Deleting file '/home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default/v4l2loopback.o'
[   86s] make: *** [../../../linux-5.19.1-lp152.9/Makefile:1857: /home/abuild/rpmbuild/BUILD/v4l2loopback-0.12.5/obj/default] Error 2
[   86s] make: Leaving directory '/usr/src/linux-5.19.1-lp152.9-obj/x86_64/default'
[   86s] error: Bad exit status from /var/tmp/rpm-tmp.5KeRtQ (%build)
```

The second appears with current rpmlint, if I remember correctly...