### PR TITLE
scripts/sequence-patch.sh: remove obsolete egrep

### DIFF
--- a/scripts/sequence-patch.sh
+++ b/scripts/sequence-patch.sh
@@ -503,7 +503,7 @@ if ! [ -d $ORIG_DIR ]; then
 fi
 
 if $VANILLA; then
-	PATCHES=( $(scripts/guards $SYMBOLS < series.conf | egrep '^patches\.(kernel\.org|rpmify)/') )
+	PATCHES=( $(scripts/guards $SYMBOLS < series.conf | grep -E '^patches\.(kernel\.org|rpmify)/') )
 else
 	PATCHES=( $(scripts/guards $SYMBOLS < series.conf) )
 fi


### PR DESCRIPTION
`scripts/sequence-patch.sh`: remove obsolete `egrep`
Avoids a warning and prepares for ultimate removal - [boo#1203092](https://bugzilla.opensuse.org/show_bug.cgi?id=1203092)