### PR TITLE
Add dtb-spacemit

### DIFF
--- a/rpm/mkspec-dtb
+++ b/rpm/mkspec-dtb
@@ -90,6 +90,7 @@ my @riscv64_package_list = (
      ['dtb-renesas',   'renesas/*.dts',     "Renesas based riscv64 systems"],
      ['dtb-sifive',    'sifive/*.dts',      "SiFive based riscv64 systems"],
      ['dtb-sophgo',    'sophgo/*.dts',      "Sophgo based riscv64 systems"],
+     ['dtb-spacemit',  'spacemit/*.dts',    "SpacemiT based riscv64 systems"],
      ['dtb-starfive',  'starfive/*.dts',    "StarFive based riscv64 systems"],
      ['dtb-thead',     'thead/*.dts',       "T-HEAD based riscv64 systems"],
 );


### PR DESCRIPTION
SpacemiT boards include MilkV-Jupiter, Banana Pi F3 and Orange Pi RV2.